### PR TITLE
Key to snap camera to the nearest 2D view

### DIFF
--- a/Scripts/CamControls.gd
+++ b/Scripts/CamControls.gd
@@ -159,8 +159,9 @@ func _ltrt() -> void: # Rotate left and right
 		await tween.finished
 		_rotating = false
 
-func _camera_face_snap() -> void:
+func _camera_face_snap() -> void: # Snap camera to nearest orthogonal face
 	var _snap = Input.is_action_just_pressed("cam_face_snap", true)
+	
 	if !_rotating and _snap:
 		_rotating = true
 		var snap_rot = Vector3.ZERO

--- a/Scripts/CamControls.gd
+++ b/Scripts/CamControls.gd
@@ -50,6 +50,7 @@ func _unhandled_input(event: InputEvent) -> void:
 	_keyControls()
 	_flip()
 	_ltrt()
+	_camera_face_snap()
 
 func _3dOrbit(mousePos: Vector2) -> void: # Rotate around pivot
 	Input.set_mouse_mode(Input.MOUSE_MODE_CAPTURED)
@@ -157,6 +158,28 @@ func _ltrt() -> void: # Rotate left and right
 		
 		await tween.finished
 		_rotating = false
+
+func _camera_face_snap() -> void:
+	var _snap = Input.is_action_just_pressed("cam_face_snap", true)
+	if !_rotating and _snap:
+		_rotating = true
+		var snap_rot = Vector3.ZERO
+		snap_rot.y = snappedf(_pivot.rotation_degrees.y, 90)
+		var tween = get_tree().create_tween()
+
+		tween.set_ease(Tween.EASE_OUT)
+		tween.set_trans(Tween.TRANS_SINE)
+
+		tween.tween_property(
+			_pivot,
+			"rotation_degrees",
+			snap_rot,
+			rotation_duration
+		)
+
+		await tween.finished
+		_rotating = false
+
 
 func _select() -> void: # Select objects (by dragging or single clicking)
 	# Make a raycast (yes I copied this from the wiki)

--- a/project.godot
+++ b/project.godot
@@ -166,6 +166,11 @@ cam_selectMulti={
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194325,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
+cam_face_snap={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194328,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 


### PR DESCRIPTION
Based on the feature mentioned in the fez-modding channel: pressing <kbd>Alt</kbd> snaps the camera to the nearest FEZ-like 2D view - i.e. the camera will only snap to front/left/right/back, not top or bottom. 
<kbd>Alt</kbd> is arbitrary, but was an attempt to keep the controls somewhat like Blender's.